### PR TITLE
Disable exclusive conncetion in reactor MQ

### DIFF
--- a/reactor/infrastructure/queue/reader.go
+++ b/reactor/infrastructure/queue/reader.go
@@ -77,7 +77,7 @@ func (r *reader) connect() error {
 		r.QueueName,
 		false,
 		false,
-		true,
+		false,
 		false,
 		nil,
 	)


### PR DESCRIPTION
Exclusive connection prevents ejaculation-counter to be restarted while the strategy is set to roll out pods.