### PR TITLE
Fix queue durability

### DIFF
--- a/reactor/infrastructure/queue/reader.go
+++ b/reactor/infrastructure/queue/reader.go
@@ -75,7 +75,7 @@ func (r *reader) connect() error {
 
 	q, err := r.Channel.QueueDeclare(
 		r.QueueName,
-		false,
+		true,
 		false,
 		false,
 		false,

--- a/supplier/service/processor.go
+++ b/supplier/service/processor.go
@@ -89,7 +89,7 @@ func (ps *processor) Execute() {
 					event, index, err := action.Event(status.Message)
 					if err != nil {
 						log.Println("Error in processing " + action.Name() + ": " + err.Error())
-						EventsErrorTotal.WithLabelValues(action.Name())
+						EventsErrorTotal.WithLabelValues(action.Name()).Inc()
 						continue
 					}
 


### PR DESCRIPTION
The durability of queue is important to keep messages persistent between broker restarts.