### PR TITLE
Send reconnection as diagnostic status

### DIFF
--- a/supplier/infrastructure/streaming/mastodon_test.go
+++ b/supplier/infrastructure/streaming/mastodon_test.go
@@ -133,8 +133,8 @@ var _ = Describe("Mastodon", func() {
 						actual, err := mastodon.Run(ctx)
 						Expect(err).NotTo(HaveOccurred())
 
-						Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-							Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+						Eventually(actual).Should(Receive(Equal(service.Error{
+							Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
 						})))
 						Eventually(actual).Should(BeClosed())
 					})
@@ -199,8 +199,8 @@ var _ = Describe("Mastodon", func() {
 									actual, err := mastodon.Run(ctx)
 									Expect(err).NotTo(HaveOccurred())
 
-									Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-										Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+									Eventually(actual).Should(Receive(Equal(service.Error{
+										Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
 									})))
 									Eventually(actual).Should(BeClosed())
 								})
@@ -230,11 +230,11 @@ var _ = Describe("Mastodon", func() {
 									actual, err := mastodon.Run(ctx)
 									Expect(err).NotTo(HaveOccurred())
 
-									Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-										Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+									Eventually(actual).Should(Receive(Equal(service.Error{
+										Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
 									})))
-									Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-										Error: errors.New("connection cannot be closed"),
+									Eventually(actual).Should(Receive(Equal(service.Error{
+										Err: errors.New("connection cannot be closed"),
 									})))
 									Eventually(actual).Should(BeClosed())
 								})
@@ -308,8 +308,8 @@ var _ = Describe("Mastodon", func() {
 										actual, err := mastodon.Run(ctx)
 										Expect(err).NotTo(HaveOccurred())
 
-										Eventually(actual).Should(Receive(WithTransform(func(m service.MessageStatus) error {
-											return m.Error
+										Eventually(actual).Should(Receive(WithTransform(func(m service.Error) error {
+											return m.Err
 										}, MatchError("unexpected EOF"))))
 										Eventually(actual).Should(BeClosed())
 									})
@@ -378,29 +378,27 @@ var _ = Describe("Mastodon", func() {
 										actual, err := mastodon.Run(ctx)
 										Expect(err).NotTo(HaveOccurred())
 
-										Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-											Message: service.Message{
-												ID: "1",
-												Account: service.Account{
-													ID:          "1",
-													Acct:        "@test",
-													DisplayName: "テスト",
-													Username:    "test",
-												},
-												Content: "テスト",
-												Emojis: []service.Emoji{
-													{Shortcode: "ios_big_sushi_1"},
-													{Shortcode: "ios_big_sushi_2"},
-													{Shortcode: "ios_big_sushi_3"},
-													{Shortcode: "ios_big_sushi_4"},
-												},
-												Tags: []service.Tag{
-													{Name: "同人avタイトルジェネレーター"},
-												},
-												IsReblog:    false,
-												InReplyToID: "<nil>",
-												Visibility:  "private",
+										Eventually(actual).Should(Receive(Equal(service.Message{
+											ID: "1",
+											Account: service.Account{
+												ID:          "1",
+												Acct:        "@test",
+												DisplayName: "テスト",
+												Username:    "test",
 											},
+											Content: "テスト",
+											Emojis: []service.Emoji{
+												{Shortcode: "ios_big_sushi_1"},
+												{Shortcode: "ios_big_sushi_2"},
+												{Shortcode: "ios_big_sushi_3"},
+												{Shortcode: "ios_big_sushi_4"},
+											},
+											Tags: []service.Tag{
+												{Name: "同人avタイトルジェネレーター"},
+											},
+											IsReblog:    false,
+											InReplyToID: "<nil>",
+											Visibility:  "private",
 										})))
 										Eventually(actual).Should(BeClosed())
 									})
@@ -459,8 +457,11 @@ var _ = Describe("Mastodon", func() {
 							actual, err := mastodon.Run(ctx)
 							Expect(err).NotTo(HaveOccurred())
 
-							Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-								Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							Eventually(actual).Should(Receive(Equal(service.Error{
+								Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							})))
+							Eventually(actual).Should(Receive(Equal(service.Reconnection{
+								In: 5 * time.Second,
 							})))
 							Eventually(actual).Should(BeClosed())
 						})
@@ -530,11 +531,17 @@ var _ = Describe("Mastodon", func() {
 							actual, err := mastodon.Run(ctx)
 							Expect(err).NotTo(HaveOccurred())
 
-							Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-								Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							Eventually(actual).Should(Receive(Equal(service.Error{
+								Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
 							})))
-							Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-								Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							Eventually(actual).Should(Receive(Equal(service.Reconnection{
+								In: 5 * time.Second,
+							})))
+							Eventually(actual).Should(Receive(Equal(service.Error{
+								Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							})))
+							Eventually(actual).Should(Receive(Equal(service.Reconnection{
+								In: 10 * time.Second,
 							})))
 							Eventually(actual).Should(BeClosed())
 						})
@@ -618,14 +625,23 @@ var _ = Describe("Mastodon", func() {
 							actual, err := mastodon.Run(ctx)
 							Expect(err).NotTo(HaveOccurred())
 
-							Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-								Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							Eventually(actual).Should(Receive(Equal(service.Error{
+								Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
 							})))
-							Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-								Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							Eventually(actual).Should(Receive(Equal(service.Reconnection{
+								In: 5 * time.Second,
 							})))
-							Eventually(actual).Should(Receive(Equal(service.MessageStatus{
-								Error: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							Eventually(actual).Should(Receive(Equal(service.Error{
+								Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							})))
+							Eventually(actual).Should(Receive(Equal(service.Reconnection{
+								In: 10 * time.Second,
+							})))
+							Eventually(actual).Should(Receive(Equal(service.Error{
+								Err: errors.New("dial tcp [::1]:443: connect: connection refused"),
+							})))
+							Eventually(actual).Should(Receive(Equal(service.Reconnection{
+								In: 20 * time.Second,
 							})))
 							Eventually(actual).Should(BeClosed())
 						})

--- a/supplier/service/model.go
+++ b/supplier/service/model.go
@@ -2,9 +2,8 @@ package service
 
 import "time"
 
-type MessageStatus struct {
-	Message Message
-	Error   error
+type Status interface {
+	status()
 }
 
 type Message struct {
@@ -33,3 +32,17 @@ type Emoji struct {
 type Tag struct {
 	Name string
 }
+
+func (m Message) status() {}
+
+type Reconnection struct {
+	In time.Duration
+}
+
+func (r Reconnection) status() {}
+
+type Error struct {
+	Err error
+}
+
+func (e Error) status() {}

--- a/supplier/service/streaming.go
+++ b/supplier/service/streaming.go
@@ -3,5 +3,5 @@ package service
 import "context"
 
 type Streaming interface {
-	Run(ctx context.Context) (<-chan MessageStatus, error)
+	Run(ctx context.Context) (<-chan Status, error)
 }


### PR DESCRIPTION
The current implementation produces the following log when reconnection occurs:
```
time="2020-05-15T20:34:53+09:00" level=error msg="Error in streaming: write tcp [240b:12:1641:3832:26c9:504a:d1ab:15a6]:60068->[2401:2500:102:3024:153:126:176:17]:443: i/o timeout"
time="2020-05-15T20:34:53+09:00" level=info msg="Reconnecting in 5s..."
time="2020-05-15T20:34:53+09:00" level=error msg="Error in streaming: websocket: bad handshake"
time="2020-05-15T20:34:58+09:00" level=info msg="Reconnecting in 10s..."
time="2020-05-15T20:34:58+09:00" level=error msg="Error in streaming: dial tcp [2401:2500:102:3024:153:126:176:17]:443: connect: connection refused"
time="2020-05-15T20:35:11+09:00" level=info msg="Reconnecting in 20s..."
time="2020-05-15T20:35:11+09:00" level=error msg="Error in streaming: dial tcp [2401:2500:102:3024:153:126:176:17]:443: connect: connection refused"
time="2020-05-15T20:35:31+09:00" level=info msg="Connected to 192.168.100.1:4000"
```

The desired log shoud come with:
1. `Error in streaming: ...`
1. `Reconnecting ...`
1. `Connected to ...`

This PR refactors the output of stream so it sends reconnection status to channel in order they can be treated (i.e., logged) in a sequence.