### PR TITLE
Initialize ejaculation_counter_streaming_message_total when connected

### DIFF
--- a/supplier/infrastructure/streaming/mastodon.go
+++ b/supplier/infrastructure/streaming/mastodon.go
@@ -154,6 +154,7 @@ func (m *mastodon) Run(ctx context.Context) (<-chan service.Status, error) {
 			server := res.Header.Get(ServerHeader)
 			if server != "" {
 				logrus.Infof("Connected to %s", server)
+				StreamingMessageTotal.WithLabelValues(server)
 			}
 
 			for {


### PR DESCRIPTION
Very convenient when administrating or debugging Mastodon connection!