### PR TITLE
Cancel reconnection to MQ in graceful shutdown

### DIFF
--- a/supplier/infrastructure/queue/writer.go
+++ b/supplier/infrastructure/queue/writer.go
@@ -132,10 +132,8 @@ func (w *writer) connect(ctx context.Context) error {
 					logrus.Errorf("Error in publishing from queue: %v", err.Error())
 				}
 
-			case _, ok := <-w.Confirmations:
-				if !ok {
-					return
-				}
+			case <-w.Confirmations:
+				return
 			}
 		}
 	}()
@@ -176,9 +174,10 @@ func (w *writer) reconnect(ctx context.Context) {
 		case <-time.After(reconnect):
 			w.disconnect()
 			err := w.connect(ctx)
-			if err == nil {
-				return
+			if err != nil {
+				continue
 			}
+			return
 		}
 	}
 }

--- a/supplier/service/processor.go
+++ b/supplier/service/processor.go
@@ -89,7 +89,7 @@ func (ps *processor) Execute(ctx context.Context) {
 					continue
 
 				case Reconnection:
-					logrus.Infoln("Reconnecting in streaming: " + status.In.String())
+					logrus.Infof("Reconnecting to streaming in %v...", status.In)
 					continue
 
 				case Message:


### PR DESCRIPTION
Fixes a bug in reactor where reconnection to MQ has caused panic since it could have never been properly cancelled via context. The previous implementation reaches `continue` statement after `reconnect` exits when receiving closure of `ctx.Done()` and all of `case`s in `select` are closed after all, which means the next step will randomly be chosen until it finally crashes.