### PR TITLE
Fix a regression in MQ confirmation

### DIFF
--- a/supplier/infrastructure/queue/writer.go
+++ b/supplier/infrastructure/queue/writer.go
@@ -132,8 +132,10 @@ func (w *writer) connect(ctx context.Context) error {
 					logrus.Errorf("Error in publishing from queue: %v", err)
 				}
 
-			case <-w.Confirmations:
-				return
+			case _, ok := <-w.Confirmations:
+				if !ok {
+					return
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
The regression caused `Publish()` to MQ to be stuck as presumably no goroutine handles confirmation.