### PR TITLE
Enable quorum queues

### DIFF
--- a/reactor/infrastructure/queue/reader.go
+++ b/reactor/infrastructure/queue/reader.go
@@ -133,7 +133,9 @@ func (r *reader) connect() error {
 		false,
 		false,
 		false,
-		nil,
+		amqp.Table{
+			"x-queue-type": "quorum",
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to declare queue in MQ channel: %w", err)

--- a/supplier/infrastructure/queue/writer.go
+++ b/supplier/infrastructure/queue/writer.go
@@ -135,7 +135,9 @@ func (w *writer) connect(ctx context.Context) error {
 		false,
 		false,
 		false,
-		nil,
+		amqp.Table{
+			"x-queue-type": "quorum",
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to declare queue in MQ channel: %w", err)


### PR DESCRIPTION
Enabling [Quorum Queues](https://www.rabbitmq.com/quorum-queues.html) in order that the queue and its contents are replicated over every node in the MQ cluster.