### PR TITLE
Disable major update for grafana/grafana

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,8 +50,8 @@ updates:
   open-pull-requests-limit: 99
   ignore:
   - dependency-name: grafana/grafana
-    versions:
-    - "~> 8.0.0"
+    update-types:
+    - version-update:semver-major
 - package-ecosystem: docker
   directory: "/mq"
   schedule:


### PR DESCRIPTION
v8.x.x is incompatible but the `ignore` option seems incorrect.