### PR TITLE
Use RabbitMQ 3.10.x series

### DIFF
--- a/mq/Dockerfile
+++ b/mq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.11.0-management
+FROM rabbitmq:3.10.8-management
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/0.5.3/elixir-1.12.2.ez /opt/rabbitmq/plugins/
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/0.5.3/rabbitmq_message_deduplication-0.5.3.ez /opt/rabbitmq/plugins/
 RUN chown rabbitmq:rabbitmq /opt/rabbitmq/plugins/*.ez && \


### PR DESCRIPTION
Broken 😕 

```
2022-10-02 11:55:45.714919+00:00 [warning] <0.55.0> The global_name_server received an unexpected message:
2022-10-02 11:55:45.714919+00:00 [warning] <0.55.0> handle_info({nodedown,'rabbit@ejaculation-counter-mq-cluster-server-1.ejaculation-counter-mq-cluster-nodes.default'}, _)
2022-10-02 11:55:45.714919+00:00 [warning] <0.55.0> 
2022-10-02 11:55:45.715182+00:00 [warning] <0.55.0> The global_name_server received an unexpected message:
2022-10-02 11:55:45.715182+00:00 [warning] <0.55.0> handle_info({nodeup,'rabbit@ejaculation-counter-mq-cluster-server-1.ejaculation-counter-mq-cluster-nodes.default'}, _)
2022-10-02 11:55:45.715182+00:00 [warning] <0.55.0> 
```