### PR TITLE
Disable update for rabbitmq

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,5 @@ updates:
     time: "00:00"
     timezone: Asia/Tokyo
   open-pull-requests-limit: 99
+  ignore:
+  - dependency-name: rabbitmq


### PR DESCRIPTION
RabbitMQ >= v3.10.8 is currently not working