### PR TITLE
Bump rabbitmq from 3.11.18-management to 3.12.0-management in /mq

### DIFF
--- a/mq/Dockerfile
+++ b/mq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.11.8-management
+FROM rabbitmq:3.12.0-management
 ARG RABBITMQ_MESSAGE_DEDUPLICATION_VERSION=0.6.1
 ARG RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION=1.13.4
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION/elixir-$RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION.ez /opt/rabbitmq/plugins/


### PR DESCRIPTION
Follows up for #525.