### PR TITLE
Use Dead Letter Exchanges to requeue failed messages

### DIFF
--- a/reactor/main.go
+++ b/reactor/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"time"
 
 	"github.com/chitoku-k/ejaculation-counter/reactor/application/server"
 	"github.com/chitoku-k/ejaculation-counter/reactor/infrastructure/action"
@@ -43,7 +44,7 @@ func main() {
 		logrus.Fatalf("Failed to initialize DB: %v", err)
 	}
 
-	reader, err := queue.NewReader("packets_topic", "packets", "packets", env)
+	reader, err := queue.NewReader("ejaculation-counter.packets", "ejaculation-counter.packets.queue", "packets", env)
 	if err != nil {
 		logrus.Fatalf("Failed to initialize reader: %v", err)
 	}
@@ -100,6 +101,7 @@ func main() {
 				action.NewThrough(through, env),
 				action.NewDoublet(doublet, env),
 			},
+			time.Now,
 		)
 		ps.Execute(ctx, reader.Packets())
 

--- a/reactor/service/packet.go
+++ b/reactor/service/packet.go
@@ -6,16 +6,19 @@ import (
 
 type Packet interface {
 	Tag() uint64
+	Timestamp() time.Time
 }
 
-func NewTick(tag uint64) Tick {
+func NewTick(tag uint64, timestamp time.Time) Tick {
 	return Tick{
-		tag: tag,
+		tag:       tag,
+		timestamp: timestamp,
 	}
 }
 
 type Tick struct {
-	tag uint64
+	tag       uint64
+	timestamp time.Time
 
 	Year  int `json:"year"`
 	Month int `json:"month"`
@@ -30,14 +33,20 @@ func (t Tick) Tag() uint64 {
 	return t.tag
 }
 
-func NewMessage(tag uint64) Message {
+func (t Tick) Timestamp() time.Time {
+	return t.timestamp
+}
+
+func NewMessage(tag uint64, timestamp time.Time) Message {
 	return Message{
-		tag: tag,
+		tag:       tag,
+		timestamp: timestamp,
 	}
 }
 
 type Message struct {
-	tag uint64
+	tag       uint64
+	timestamp time.Time
 
 	ID          string    `json:"id"`
 	Account     Account   `json:"account"`
@@ -71,4 +80,8 @@ func (m Message) Name() string {
 
 func (m Message) Tag() uint64 {
 	return m.tag
+}
+
+func (m Message) Timestamp() time.Time {
+	return m.timestamp
 }

--- a/reactor/service/queue.go
+++ b/reactor/service/queue.go
@@ -6,5 +6,6 @@ type QueueReader interface {
 	Consume(ctx context.Context)
 	Packets() <-chan Packet
 	Ack(tag uint64) error
+	Reject(tag uint64) error
 	Close(exit bool) error
 }

--- a/supplier/main.go
+++ b/supplier/main.go
@@ -51,7 +51,7 @@ func main() {
 		wg.Done()
 	}()
 
-	writer, err := queue.NewWriter(ctx, "packets_topic", "packets", "packets", env)
+	writer, err := queue.NewWriter(ctx, "ejaculation-counter.packets", "packets", env)
 	if err != nil {
 		logrus.Fatalf("Failed to initialize writer: %v", err)
 	}

--- a/supplier/service/packet.go
+++ b/supplier/service/packet.go
@@ -7,6 +7,7 @@ import (
 
 type Packet interface {
 	Name() string
+	Timestamp() time.Time
 	HashCode() int64
 }
 
@@ -20,6 +21,10 @@ func (t Tick) status() {}
 
 func (t Tick) Name() string {
 	return "packets.tick"
+}
+
+func (t Tick) Timestamp() time.Time {
+	return time.Date(t.Year, time.Month(t.Month), t.Day, 0, 0, 0, 0, time.Local)
 }
 
 func (t Tick) HashCode() int64 {
@@ -61,6 +66,10 @@ func (m Message) status() {}
 
 func (m Message) Name() string {
 	return "packets.message"
+}
+
+func (m Message) Timestamp() time.Time {
+	return m.CreatedAt
 }
 
 func (m Message) HashCode() int64 {


### PR DESCRIPTION
This PR introduces use of [Dead Letter Exchanges](https://www.rabbitmq.com/dlx.html) to requeue failed messages with a certain amount of delay.

With this new implementation, a message is rejected by reactor when it fails to process it, dead-lettered, and republished to the new dedicated exchange called `ejaculation-counter.packets.dl`. The TTL of the exchange is set to 5 minutes so it is automatically dead-lettered again after 5 minutes to the original queue called `ejaculation-counter.packets`. Since this cycle does not stop without any application-level handling, this PR adds timestamp to every message at supplier and reactor acknowledges any messages older than 30 minutes without further process.

![image](https://github.com/chitoku-k/ejaculation-counter/assets/6535425/74e26f81-d482-4393-a931-52d2004fe8cc)

To get this to work with [RabbitMQ Message Deduplication Plugin](https://github.com/noxdafox/rabbitmq-message-deduplication), the main exchange needs to set its `x-cache-ttl` shorter than 5 minutes; otherwise, when the same message was requeued to the exchange it would simply be dropped (or “deduplicated”).