### PR TITLE
Revert "Bump rabbitmq from 3.12.13-management to 3.13.0-management in /mq"

### DIFF
--- a/mq/Dockerfile
+++ b/mq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.13.0-management
+FROM rabbitmq:3.12.13-management
 ARG RABBITMQ_MESSAGE_DEDUPLICATION_VERSION=0.6.2
 ARG RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION=1.14.0
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION/elixir-$RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION.ez /opt/rabbitmq/plugins/


### PR DESCRIPTION
This reverts commit a0959c8a594d5c190de80854476c5cfe0647cccd.