### PR TITLE
Refactor supplier

### DIFF
--- a/supplier/infrastructure/config/env_test.go
+++ b/supplier/infrastructure/config/env_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Environment", func() {
 
 			It("returns an error", func() {
 				_, err := config.Get()
-				Expect(err).To(MatchError(MatchRegexp("^missing env\\(s\\): ")))
+				Expect(err).To(MatchError(HavePrefix("missing:")))
 			})
 		})
 
@@ -68,7 +68,7 @@ var _ = Describe("Environment", func() {
 
 				It("returns an error", func() {
 					_, err := config.Get()
-					Expect(err).To(MatchError(MatchRegexp("^failed to parse log level: ")))
+					Expect(err).To(MatchError(HavePrefix("LOG_LEVEL is invalid:")))
 				})
 			})
 

--- a/supplier/infrastructure/scheduler/cron.go
+++ b/supplier/infrastructure/scheduler/cron.go
@@ -4,22 +4,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/chitoku-k/ejaculation-counter/supplier/infrastructure/config"
 	"github.com/chitoku-k/ejaculation-counter/supplier/service"
 	"github.com/robfig/cron/v3"
 )
 
 type scheduler struct {
-	cron        *cron.Cron
-	ch          chan service.Tick
-	Environment config.Environment
+	cron *cron.Cron
+	ch   chan service.Tick
 }
 
-func New(environment config.Environment) (service.Scheduler, error) {
+func New() (service.Scheduler, error) {
 	s := scheduler{
-		cron:        cron.New(),
-		ch:          make(chan service.Tick),
-		Environment: environment,
+		cron: cron.New(),
+		ch:   make(chan service.Tick),
 	}
 
 	_, err := s.cron.AddFunc("00 00 * * *", s.handle)

--- a/supplier/infrastructure/streaming/mastodon.go
+++ b/supplier/infrastructure/streaming/mastodon.go
@@ -76,7 +76,7 @@ func convertContent(content string) string {
 }
 
 func convertEmojis(emojis []mast.Emoji) []service.Emoji {
-	var result []service.Emoji
+	result := make([]service.Emoji, 0, len(emojis))
 
 	for _, v := range emojis {
 		result = append(result, service.Emoji{
@@ -88,7 +88,7 @@ func convertEmojis(emojis []mast.Emoji) []service.Emoji {
 }
 
 func convertTags(tags []mast.Tag) []service.Tag {
-	var result []service.Tag
+	result := make([]service.Tag, 0, len(tags))
 
 	for _, v := range tags {
 		result = append(result, service.Tag{
@@ -186,7 +186,7 @@ func (m *mastodon) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse server URL: %w", err)
 	}
-	u.Scheme = strings.ReplaceAll(u.Scheme, "http", "ws")
+	u.Scheme = strings.Replace(u.Scheme, "http", "ws", 1)
 	u.Path = path.Join(u.Path, "/api/v1/streaming")
 	u.RawQuery = params.Encode()
 
@@ -222,9 +222,9 @@ func (m *mastodon) Run(ctx context.Context) error {
 
 		for {
 			var stream mast.Stream
-			err = m.conn.ReadJSON(&stream)
+			err := m.conn.ReadJSON(&stream)
 			if err != nil {
-				err = m.disconnect(ctx, err)
+				err := m.disconnect(ctx, err)
 				if err != nil {
 					return err
 				}
@@ -274,7 +274,7 @@ func (m *mastodon) Run(ctx context.Context) error {
 			}
 
 			if status.InReplyToID != nil {
-				message.InReplyToID = fmt.Sprint(status.InReplyToID)
+				message.InReplyToID = status.InReplyToID.(string)
 			}
 
 			StreamingMessageTotal.WithLabelValues(server).Inc()

--- a/supplier/infrastructure/streaming/mastodon.go
+++ b/supplier/infrastructure/streaming/mastodon.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chitoku-k/ejaculation-counter/supplier/infrastructure/config"
 	"github.com/chitoku-k/ejaculation-counter/supplier/infrastructure/wrapper"
 	"github.com/chitoku-k/ejaculation-counter/supplier/service"
 	"github.com/gorilla/websocket"
@@ -43,28 +42,28 @@ const (
 )
 
 type mastodon struct {
-	ch          chan service.Status
-	conn        wrapper.Conn
-	Environment config.Environment
-	Client      *mast.Client
-	Dialer      wrapper.Dialer
-	Timer       wrapper.Timer
+	ch     chan service.Status
+	conn   wrapper.Conn
+	Client *mast.Client
+	Dialer wrapper.Dialer
+	Timer  wrapper.Timer
+	Stream string
 }
 
 func NewMastodon(
-	environment config.Environment,
 	dialer wrapper.Dialer,
 	timer wrapper.Timer,
+	serverURL, accessToken, stream string,
 ) service.Streaming {
 	return &mastodon{
-		ch:          make(chan service.Status),
-		Environment: environment,
+		ch: make(chan service.Status),
 		Client: mast.NewClient(&mast.Config{
-			Server:      environment.Mastodon.ServerURL,
-			AccessToken: environment.Mastodon.AccessToken,
+			Server:      serverURL,
+			AccessToken: accessToken,
 		}),
 		Dialer: dialer,
 		Timer:  timer,
+		Stream: stream,
 	}
 }
 
@@ -181,7 +180,7 @@ func (m *mastodon) Run(ctx context.Context) error {
 
 	params := url.Values{}
 	params.Set("access_token", m.Client.Config.AccessToken)
-	params.Set("stream", m.Environment.Mastodon.Stream)
+	params.Set("stream", m.Stream)
 
 	u, err := url.Parse(m.Client.Config.Server)
 	if err != nil {

--- a/supplier/infrastructure/streaming/mastodon_test.go
+++ b/supplier/infrastructure/streaming/mastodon_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/chitoku-k/ejaculation-counter/supplier/infrastructure/config"
 	"github.com/chitoku-k/ejaculation-counter/supplier/infrastructure/streaming"
 	"github.com/chitoku-k/ejaculation-counter/supplier/infrastructure/wrapper"
 	"github.com/chitoku-k/ejaculation-counter/supplier/service"
@@ -39,23 +38,20 @@ var _ = Describe("Mastodon", func() {
 
 	Describe("Run()", func() {
 		var (
-			env      config.Environment
-			mastodon service.Streaming
-			ctx      context.Context
-			cancel   context.CancelFunc
-			ch       chan time.Time
-			stream   mast.Stream
+			serverURL   string
+			accessToken string
+			mastodon    service.Streaming
+			ctx         context.Context
+			cancel      context.CancelFunc
+			ch          chan time.Time
+			stream      mast.Stream
 		)
 
 		Context("parsing server URL fails", func() {
 			BeforeEach(func() {
-				env = config.Environment{
-					Mastodon: config.Mastodon{
-						ServerURL:   ":/",
-						AccessToken: "token",
-					},
-				}
-				mastodon = streaming.NewMastodon(env, d, t)
+				serverURL = ":/"
+				accessToken = "token"
+				mastodon = streaming.NewMastodon(d, t, serverURL, accessToken, "user")
 			})
 
 			It("returns an error", func() {
@@ -66,14 +62,9 @@ var _ = Describe("Mastodon", func() {
 
 		Context("parsing server URL succeeds", func() {
 			BeforeEach(func() {
-				env = config.Environment{
-					Mastodon: config.Mastodon{
-						ServerURL:   "https://mastodon.example.com",
-						Stream:      "user",
-						AccessToken: "token",
-					},
-				}
-				mastodon = streaming.NewMastodon(env, d, t)
+				serverURL = "https://mastodon.example.com"
+				accessToken = "token"
+				mastodon = streaming.NewMastodon(d, t, serverURL, accessToken, "user")
 				ctx, cancel = context.WithCancel(context.Background())
 			})
 
@@ -910,20 +901,17 @@ var _ = Describe("Mastodon", func() {
 
 	Describe("Close()", func() {
 		var (
-			env      config.Environment
-			mastodon service.Streaming
+			serverURL   string
+			accessToken string
+			mastodon    service.Streaming
 		)
 
 		Context("not exit", func() {
 			Context("connection not established", func() {
 				BeforeEach(func() {
-					env = config.Environment{
-						Mastodon: config.Mastodon{
-							ServerURL:   ":/",
-							AccessToken: "token",
-						},
-					}
-					mastodon = streaming.NewMastodon(env, d, t)
+					serverURL = ":/"
+					accessToken = "token"
+					mastodon = streaming.NewMastodon(d, t, serverURL, accessToken, "user")
 				})
 
 				It("does nothing", func() {
@@ -936,13 +924,9 @@ var _ = Describe("Mastodon", func() {
 		Context("exit", func() {
 			Context("connection not established", func() {
 				BeforeEach(func() {
-					env = config.Environment{
-						Mastodon: config.Mastodon{
-							ServerURL:   ":/",
-							AccessToken: "token",
-						},
-					}
-					mastodon = streaming.NewMastodon(env, d, t)
+					serverURL = ":/"
+					accessToken = "token"
+					mastodon = streaming.NewMastodon(d, t, serverURL, accessToken, "user")
 				})
 
 				It("does nothing", func() {

--- a/supplier/main.go
+++ b/supplier/main.go
@@ -37,9 +37,7 @@ func main() {
 		slog.Error("Failed to initialize config", slog.Any("err", err))
 		os.Exit(1)
 	}
-
-	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: env.LogLevel})
-	slog.SetDefault(slog.New(handler))
+	slog.SetLogLoggerLevel(env.LogLevel)
 
 	s, err := scheduler.New(env)
 	if err != nil {

--- a/supplier/main.go
+++ b/supplier/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 	slog.SetLogLoggerLevel(env.LogLevel)
 
-	s, err := scheduler.New(env)
+	s, err := scheduler.New()
 	if err != nil {
 		slog.Error("Failed to initialize scheduler", slog.Any("err", err))
 		os.Exit(1)
@@ -53,16 +53,23 @@ func main() {
 		wg.Done()
 	}()
 
-	writer, err := queue.NewWriter(ctx, "ejaculation-counter.packets", "packets", env)
+	writer, err := queue.NewWriter(
+		ctx,
+		"ejaculation-counter.packets", "packets",
+		env.Queue.Host, env.Queue.Username, env.Queue.Password,
+		env.Queue.SSLCert, env.Queue.SSLKey, env.Queue.SSLRootCert,
+	)
 	if err != nil {
 		slog.Error("Failed to initialize writer", slog.Any("err", err))
 		os.Exit(1)
 	}
 
 	mastodon := streaming.NewMastodon(
-		env,
 		wrapper.NewDialer(websocket.DefaultDialer),
 		wrapper.NewTimer(),
+		env.Mastodon.ServerURL,
+		env.Mastodon.AccessToken,
+		env.Mastodon.Stream,
 	)
 
 	wg.Add(1)


### PR DESCRIPTION
This PR refactors supplier in order to:
1. decouple streaming and queue from `infrastructure/config`
1. make interfaces consistent across the project