### PR TITLE
Use `strings.EqualFold()` to perform a case-insensitive comparison

### DIFF
--- a/reactor/infrastructure/config/env.go
+++ b/reactor/infrastructure/config/env.go
@@ -127,14 +127,14 @@ func Get() (env Environment, errs error) {
 }
 
 func parseLogLevel(lvl string) (slog.Level, error) {
-	switch strings.ToLower(lvl) {
-	case "error":
+	switch {
+	case strings.EqualFold(lvl, "error"):
 		return slog.LevelError, nil
-	case "warn", "warning":
+	case strings.EqualFold(lvl, "warn"), strings.EqualFold(lvl, "warning"):
 		return slog.LevelWarn, nil
-	case "info":
+	case strings.EqualFold(lvl, "info"):
 		return slog.LevelInfo, nil
-	case "debug":
+	case strings.EqualFold(lvl, "debug"):
 		return slog.LevelDebug, nil
 	}
 

--- a/supplier/infrastructure/config/env.go
+++ b/supplier/infrastructure/config/env.go
@@ -79,14 +79,14 @@ func Get() (env Environment, errs error) {
 }
 
 func parseLogLevel(lvl string) (slog.Level, error) {
-	switch strings.ToLower(lvl) {
-	case "error":
+	switch {
+	case strings.EqualFold(lvl, "error"):
 		return slog.LevelError, nil
-	case "warn", "warning":
+	case strings.EqualFold(lvl, "warn"), strings.EqualFold(lvl, "warning"):
 		return slog.LevelWarn, nil
-	case "info":
+	case strings.EqualFold(lvl, "info"):
 		return slog.LevelInfo, nil
-	case "debug":
+	case strings.EqualFold(lvl, "debug"):
 		return slog.LevelDebug, nil
 	}
 


### PR DESCRIPTION
Using `strings.ToLower()` requires extra allocation while `strings.EqualFold()` does not.