### PR TITLE
Bump rabbitmq-message-deduplication from 0.6.3 to 0.6.4 in /mq

### DIFF
--- a/mq/Dockerfile
+++ b/mq/Dockerfile
@@ -1,5 +1,5 @@
 FROM rabbitmq:3.13.7-management
-ARG RABBITMQ_MESSAGE_DEDUPLICATION_VERSION=0.6.3
+ARG RABBITMQ_MESSAGE_DEDUPLICATION_VERSION=0.6.4
 ARG RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION=1.16.3
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION/elixir-$RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION.ez /opt/rabbitmq/plugins/
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION/rabbitmq_message_deduplication-$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION.ez /opt/rabbitmq/plugins/


### PR DESCRIPTION
Bumps rabbitmq-message-deduplication from 0.6.3 to 0.6.4.