### PR TITLE
Publish `latest` images on push to master branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,14 +30,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/bake-action@v6
-        env:
-          TAG: ${{ github.ref_name }}
         with:
           files: docker-bake.hcl
           push: true
           set: |
             supplier.args.PORT=443
             reactor.args.PORT=443
+            supplier.tags=ghcr.io/chitoku-k/ejaculation-counter/supplier:${{ github.ref_name }}
+            reactor.tags=ghcr.io/chitoku-k/ejaculation-counter/reactor:${{ github.ref_name }}
+            grafana.tags=ghcr.io/chitoku-k/ejaculation-counter/grafana:${{ github.ref_name }}
+            mq.tags=ghcr.io/chitoku-k/ejaculation-counter/mq:${{ github.ref_name }}
+            web.tags=ghcr.io/chitoku-k/ejaculation-counter/web:${{ github.ref_name }}
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,23 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Log into Container Registry
+        if: ${{ github.ref_name == 'master' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         uses: docker/bake-action@v6
         with:
           files: docker-bake.hcl
+          push: ${{ github.ref_name == 'master' }}
           set: |
+            supplier.tags=ghcr.io/chitoku-k/ejaculation-counter/supplier:latest
+            reactor.tags=ghcr.io/chitoku-k/ejaculation-counter/reactor:latest
+            grafana.tags=ghcr.io/chitoku-k/ejaculation-counter/grafana:latest
+            mq.tags=ghcr.io/chitoku-k/ejaculation-counter/mq:latest
+            web.tags=ghcr.io/chitoku-k/ejaculation-counter/web:latest
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,47 +1,23 @@
-variable "TAG" {
-    default = "latest"
-}
-
 group "default" {
     targets = ["supplier", "reactor", "grafana", "mq", "web"]
 }
 
 target "supplier" {
     context = "./supplier"
-    tags = [
-        "ghcr.io/chitoku-k/ejaculation-counter/supplier:latest",
-        "ghcr.io/chitoku-k/ejaculation-counter/supplier:${TAG}",
-    ]
 }
 
 target "reactor" {
     context = "./reactor"
-    tags = [
-        "ghcr.io/chitoku-k/ejaculation-counter/reactor:latest",
-        "ghcr.io/chitoku-k/ejaculation-counter/reactor:${TAG}",
-    ]
 }
 
 target "grafana" {
     context = "./grafana"
-    tags = [
-        "ghcr.io/chitoku-k/ejaculation-counter/grafana:latest",
-        "ghcr.io/chitoku-k/ejaculation-counter/grafana:${TAG}",
-    ]
 }
 
 target "mq" {
     context = "./mq"
-    tags = [
-        "ghcr.io/chitoku-k/ejaculation-counter/mq:latest",
-        "ghcr.io/chitoku-k/ejaculation-counter/mq:${TAG}",
-    ]
 }
 
 target "web" {
     context = "."
-    tags = [
-        "ghcr.io/chitoku-k/ejaculation-counter/web:latest",
-        "ghcr.io/chitoku-k/ejaculation-counter/web:${TAG}",
-    ]
 }


### PR DESCRIPTION
This PR changes CI/CD to publish `latest` images on push to master branch. The `latest` tag is no longer stable.