### PR TITLE
Bump rabbitmq-message-deduplication from 0.6.4 to  in /mq

### DIFF
--- a/mq/Dockerfile
+++ b/mq/Dockerfile
@@ -1,6 +1,6 @@
 FROM rabbitmq:4.1.0-management
-ARG RABBITMQ_MESSAGE_DEDUPLICATION_VERSION=0.6.4
-ARG RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION=1.16.3
+ARG RABBITMQ_MESSAGE_DEDUPLICATION_VERSION=
+ARG RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION=
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION/elixir-$RABBITMQ_MESSAGE_DEDUPLICATION_ELIXIR_VERSION.ez /opt/rabbitmq/plugins/
 ADD https://github.com/noxdafox/rabbitmq-message-deduplication/releases/download/$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION/rabbitmq_message_deduplication-$RABBITMQ_MESSAGE_DEDUPLICATION_VERSION.ez /opt/rabbitmq/plugins/
 RUN chown rabbitmq:rabbitmq /opt/rabbitmq/plugins/*.ez && \


### PR DESCRIPTION
Bumps rabbitmq-message-deduplication from 0.6.4 to .