### PR TITLE
Close event body immediately rather than after `io.Discard`

### DIFF
--- a/reactor/infrastructure/invoker/reply.go
+++ b/reactor/infrastructure/invoker/reply.go
@@ -75,7 +75,6 @@ func pack(r io.Reader) (string, int, error) {
 
 func (r *reply) Send(ctx context.Context, event service.ReplyEvent) error {
 	defer func() {
-		_, _ = io.Copy(io.Discard, event.Body)
 		_ = event.Body.Close()
 	}()
 


### PR DESCRIPTION
This PR fixes the post-process of reply so it no longer firstly copies event body to `io.Discard` and then closes it.