### PR TITLE
Add a workaround for provisioning grafana-postgresql-datasource

### DIFF
--- a/grafana/datasources/database.yml
+++ b/grafana/datasources/database.yml
@@ -12,3 +12,7 @@ datasources:
       password: $POSTGRES_PASSWORD
     jsonData:
       sslmode: $POSTGRES_SSLMODE
+      # FIXME: Remove `jsonData.database` when it is no longer required:
+      # - https://github.com/grafana/grafana/blob/v12.2.0/packages/grafana-sql/src/datasource/SqlDatasource.ts#L54-L61
+      # - https://github.com/grafana/grafana/blob/v12.2.0/packages/grafana-sql/src/datasource/SqlDatasource.ts#L152-L157
+      database: $POSTGRES_DB


### PR DESCRIPTION
This PR adds a workaround for the following error that occurs when provisioning `grafana-postgresql-datasource` since #991:

> You do not currently have a default database configured for this data source. Postgres requires a default database with which to connect. Please configure one through the Data Sources Configuration page, or if you are using a provisioning file, update that configuration file with a default database.

![](https://github.com/user-attachments/assets/c124fab7-5117-4bb0-b860-e45df17c5b3d)